### PR TITLE
Hook signup page with backend and add errors reporting

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,19 +1,28 @@
 import React from "react";
 import { BrowserRouter as Router, Route } from "react-router-dom";
+import { Provider } from "react-redux";
 
 import Home from "./components/layout/Home";
 import CreateAccount from "./components/create-account/CreateAccount";
+import store from "./store.js";
 
 import "./css/App.css";
 
 function App() {
     return (
-        <Router>
-            <div className="App">
-                <Route exact path="/" component={Home} />
-                <Route exact path="/create-account" component={CreateAccount} />
-            </div>
-        </Router>
+        <Provider store={store}>
+            {" "}
+            <Router>
+                <div className="App">
+                    <Route exact path="/" component={Home} />
+                    <Route
+                        exact
+                        path="/create-account"
+                        component={CreateAccount}
+                    />
+                </div>
+            </Router>
+        </Provider>
     );
 }
 

--- a/client/src/actions/authActions.js
+++ b/client/src/actions/authActions.js
@@ -1,0 +1,22 @@
+import axios from "axios";
+// import jwt_decode from "jwt-decode";
+// import setAuthToken from "../utils/setAuthToken";
+
+import { GET_ERRORS, SET_CURRENT_USER } from "./types";
+
+// Register an user
+export const registerUser = (new_user_data, history) => (dispatch) => {
+    axios
+        .post("/api/users/register", new_user_data)
+        .then((res) => {
+            history.push("/");
+            console.log(res);
+        })
+        .catch((err) => {
+            console.log(err);
+            dispatch({
+                type: GET_ERRORS,
+                payload: err.response.data,
+            });
+        });
+};

--- a/client/src/actions/types.js
+++ b/client/src/actions/types.js
@@ -1,0 +1,2 @@
+export const GET_ERRORS = "GET_ERRORS";
+export const SET_CURRENT_USER = "SET_CURRENT_USER";

--- a/client/src/components/create-account/CreateAccount.js
+++ b/client/src/components/create-account/CreateAccount.js
@@ -1,6 +1,10 @@
 import React, { Component } from "react";
+import { connect } from "react-redux";
+import { withRouter } from "react-router-dom";
 import { Link } from "react-router-dom";
+import PropTypes from "prop-types";
 
+import { registerUser } from "../../actions/authActions";
 import TextFieldGroup from "../common/TextFieldGroup";
 
 import "../../css/CreateAccount.css";
@@ -9,6 +13,7 @@ class CreateAccount extends Component {
     constructor(props) {
         super(props);
         this.state = {
+            name: "",
             email: "",
             username: "",
             password: "",
@@ -25,7 +30,21 @@ class CreateAccount extends Component {
 
     onSubmit(e) {
         e.preventDefault();
-        console.log("TODO: Handle submitting form");
+        const new_user_data = {
+            name: this.state.name,
+            email: this.state.email,
+            username: this.state.username,
+            password: this.state.password,
+            password2: this.state.password2,
+        };
+        console.log("New user: ", new_user_data);
+        this.props.registerUser(new_user_data, this.props.history);
+    }
+
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.errors) {
+            this.setState({ errors: nextProps.errors });
+        }
     }
 
     render() {
@@ -37,6 +56,14 @@ class CreateAccount extends Component {
                     <p>Điền thông tin để đăng ký tài khoản.</p>
                     <hr />
                     <small className="d-block pb-3">* yêu cầu</small>
+                    <TextFieldGroup
+                        placeholder="* Họ và Tên của bạn"
+                        name="name"
+                        value={this.state.name}
+                        onChange={this.onChange}
+                        error={errors.name}
+                        info="Họ và Tên"
+                    />
                     <TextFieldGroup
                         placeholder="* Email của bạn"
                         name="email"
@@ -64,10 +91,10 @@ class CreateAccount extends Component {
                     />
                     <TextFieldGroup
                         placeholder="* Xác nhận lại"
-                        name="password"
-                        value={this.state.password}
+                        name="password2"
+                        value={this.state.password2}
                         onChange={this.onChange}
-                        error={errors.password}
+                        error={errors.password2}
                         info="Xác nhận lại mật khẩu"
                         type="password"
                     />
@@ -86,10 +113,10 @@ class CreateAccount extends Component {
                         .
                     </p>
                     <div className="clearfix">
-                        <button type="button" className="signup-cancel-btn">
+                        <Link to="/" className="cancel-btn">
                             Huỷ
-                        </button>
-                        <button type="submit" className="signup-submit-btn">
+                        </Link>
+                        <button type="submit" className="submit-btn">
                             Đăng Ký
                         </button>
                     </div>
@@ -99,4 +126,15 @@ class CreateAccount extends Component {
     }
 }
 
-export default CreateAccount;
+CreateAccount.propTypes = {
+    registerUser: PropTypes.func.isRequired,
+};
+
+// Get state in component
+const mapStateToProps = (state) => ({
+    errors: state.errors,
+});
+
+export default connect(mapStateToProps, { registerUser })(
+    withRouter(CreateAccount)
+);

--- a/client/src/css/CreateAccount.css
+++ b/client/src/css/CreateAccount.css
@@ -10,34 +10,41 @@ input[type="password"]:focus {
     outline: none;
 }
 
-button {
-    color: white;
+.cancel-btn:hover,
+.submit-btn:hover {
+    opacity: 1;
+}
+
+/* Extra styles for the cancel button */
+.cancel-btn {
+    padding: 14px 20px;
+    background-color: #f44336;
+}
+
+.submit-btn {
+    background-color: #4caf50;
+}
+
+/* Float cancel and signup buttons and add an equal width */
+.cancel-btn,
+.submit-btn {
+    float: left;
+    width: 50%;
     padding: 14px 20px;
     margin: 8px 0;
     border: none;
     cursor: pointer;
     opacity: 0.9;
+    text-align: center;
 }
 
-button:hover {
-    opacity: 1;
+.cancel-btn {
+    color: black;
 }
 
-/* Extra styles for the cancel button */
-.signup-cancel-btn {
-    padding: 14px 20px;
-    background-color: #f44336;
-}
-
-.signup-submit-btn {
-    background-color: #4caf50;
-}
-
-/* Float cancel and signup buttons and add an equal width */
-.signup-cancel-btn,
-.signup-submit-btn {
-    float: left;
-    width: 50%;
+.cancel-btn:hover {
+    color: black;
+    text-decoration: none;
 }
 
 .form-container {

--- a/client/src/reducers/authReducer.js
+++ b/client/src/reducers/authReducer.js
@@ -1,0 +1,20 @@
+import { SET_CURRENT_USER } from "../actions/types";
+import isEmpty from "../validation/is-empty";
+
+const initialState = {
+    isAuthenticated: false,
+    user: {},
+};
+
+export default function (state = initialState, action) {
+    switch (action.type) {
+        case SET_CURRENT_USER:
+            return {
+                ...state,
+                isAuthenticated: !isEmpty(action.payload),
+                user: action.payload,
+            };
+        default:
+            return state;
+    }
+}

--- a/client/src/reducers/errorReducer.js
+++ b/client/src/reducers/errorReducer.js
@@ -1,0 +1,12 @@
+import { GET_ERRORS } from "../actions/types";
+
+const initialState = {};
+
+export default function (state = initialState, action) {
+    switch (action.type) {
+        case GET_ERRORS:
+            return action.payload;
+        default:
+            return state;
+    }
+}

--- a/client/src/reducers/index.js
+++ b/client/src/reducers/index.js
@@ -1,0 +1,9 @@
+import { combineReducers } from "redux";
+
+import authReducer from "./authReducer";
+import errorReducer from "./errorReducer";
+
+export default combineReducers({
+    auth: authReducer,
+    errors: errorReducer,
+});

--- a/client/src/store.js
+++ b/client/src/store.js
@@ -1,0 +1,18 @@
+import thunk from "redux-thunk";
+import { createStore, applyMiddleware, compose } from "redux";
+
+import rootReducer from "./reducers";
+
+const initialState = {};
+const middleware = [thunk];
+const store = createStore(
+    rootReducer,
+    initialState,
+    compose(
+        applyMiddleware(...middleware),
+        window.__REDUX_DEVTOOLS_EXTENSION__ &&
+            window.__REDUX_DEVTOOLS_EXTENSION__()
+    )
+);
+
+export default store;

--- a/client/src/validation/is-empty.js
+++ b/client/src/validation/is-empty.js
@@ -1,0 +1,7 @@
+const isEmpty = (value) =>
+    value === undefined ||
+    value === null ||
+    (typeof value === "object" && Object.keys(value).length === 0) ||
+    (typeof value === "string" && value.trim().length === 0);
+
+export default isEmpty;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     },
     "homepage": "https://github.com/nguyenla/prodigy#readme",
     "dependencies": {
+        "axios": "^0.20.0",
         "bcryptjs": "^2.4.3",
         "body-parser": "^1.19.0",
         "classnames": "^2.2.6",
@@ -28,12 +29,14 @@
         "express": "^4.17.1",
         "gravatar": "^1.8.1",
         "jsonwebtoken": "^8.5.1",
+        "jwt-decode": "^3.0.0",
         "mongoose": "^5.10.6",
         "passport": "^0.4.1",
         "passport-jwt": "^4.0.0",
         "react-redux": "^7.2.1",
         "react-router-dom": "^5.2.0",
         "redux": "^4.0.5",
+        "redux-thunk": "^2.3.0",
         "validator": "^13.1.17"
     },
     "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const mongoose = require("mongoose");
 const bodyParser = require("body-parser");
+const passport = require("passport");
 
 const users = require("./routes/api/users");
 const profile = require("./routes/api/profile");
@@ -24,6 +25,12 @@ mongoose
     });
 
 app.get("/", (req, res) => res.send("Hello world!"));
+
+// Passport middleware
+app.use(passport.initialize());
+
+// Passport config
+require("./config/passport")(passport);
 
 // Use Routes
 app.use("/api/users", users);


### PR DESCRIPTION
This PR does the following:
- Add a "name" field that is required when an user signs up
- Read user's inputs on sign-up page, validate them, and send them to MongoDB
- Add errors reporting when the user's input is bad
- Introduce the React's reducer - action pattern
- Use jwt to sign token when authentication succeeds